### PR TITLE
Eliminate REMOVE rules for plural disambiguation, use SELECT only

### DIFF
--- a/apertium-bel.bel.rlx
+++ b/apertium-bel.bel.rlx
@@ -152,64 +152,56 @@ SELECT (adj $$GENDER $$CASE) IF (-1 Adv) (-2 Adv) (-3 (n $$GENDER $$CASE)) ;
 SELECT (n pl nom) IF (1 Adv) (2 (adj pl nom)) ;
     ## Мовы вельмі прыгожыя. → prefer plural nominative noun when adjective is plural nominative
 
-# Rule 4: Remove singular genitive reading when we have plural nominative adjective context
-REMOVE (n sg gen) IF (1 Adv) (2 (adj pl nom)) ;
-    ## Мовы вельмі прыгожыя. → remove wrong singular genitive reading
-
-# Rule 5: Select plural nominative for nouns with determiner + adverb + plural adjective
+# Rule 4: Select plural nominative for nouns with determiner + adverb + plural adjective
 SELECT (n pl nom) IF (-1 Det) (1 Adv) (2 (adj pl nom)) ;
     ## Гэтыя мовы вельмі прыгожыя. → handle determiner + noun + adv + adj pattern
 
-# Rule 6: Remove singular genitive with determiner context
-REMOVE (n sg gen) IF (-1 Det) (1 Adv) (2 (adj pl nom)) ;
-    ## Гэтыя мовы вельмі прыгожыя. → remove wrong singular genitive with determiner
-
 # ===== COORDINATION AGREEMENT RULES =====
 
-# Rule 7: General coordinated adjective agreement
+# Rule 5: General coordinated adjective agreement
 SELECT A + $$GENDER + $$CASE IF (-1 CC) (-2 (adj $$GENDER $$CASE)) ;
     ## Coordinated adjectives should have same gender and case
 
 # ===== GENERAL AGREEMENT RULES =====
 # Universal rules using variables (adapted from Russian)
 
-# Rule 8: General adjective-noun agreement
+# Rule 6: General adjective-noun agreement
 SELECT A + $$GENDER + $$CASE IF (0C A) (1C N + $$GENDER + $$CASE) ;
     ## Select adjective that matches following noun in gender and case
 
-# Rule 9: Adjective agreement after other adjectives (chains)
+# Rule 7: Adjective agreement after other adjectives (chains)
 SELECT A + $$CASE IF (0C A) (-1C A + $$CASE LINK -1C* Pr BARRIER (*) - A - Adv - Det) ;
     ## Adjective chains should agree in case
 
 # ===== DETERMINER AGREEMENT RULES =====
 
-# Rule 10: Determiner-noun agreement
+# Rule 8: Determiner-noun agreement
 SELECT Det + $$GENDER + $$CASE IF (1C* N + $$GENDER + $$CASE BARRIER CASE - $$CASE) ;
     ## Determiner should match noun gender and case
 
 # ===== PREPOSITIONAL AGREEMENT RULES =====
 # Agreement patterns after prepositions (adapted from Russian)
 
-# Rule 11: Adjective agreement after prepositions
+# Rule 9: Adjective agreement after prepositions
 SELECT A + $$CASE IF (-1C Pr) (0C A OR N) (1C N + $$CASE) ;
     ## Adjective after preposition should match noun case
 
 # ===== PROPER NAME AGREEMENT RULES =====
 # Agreement for proper names (adapted from Russian)
 
-# Rule 12: Proper name agreement (first name + surname)
+# Rule 10: Proper name agreement (first name + surname)
 SELECT Ant + $$CASE IF (1C Cog + $$CASE) ;
     ## First name should match surname case
 
-# Rule 13: Proper name agreement (surname follows first name)
+# Rule 11: Proper name agreement (surname follows first name)
 SELECT Cog + $$CASE IF (-1C Ant + $$CASE) ;
     ## Surname should match first name case
 
-# Rule 14: Gender agreement for proper names with titles
+# Rule 12: Gender agreement for proper names with titles
 SELECT $$GENDER IF (0C Ant) (-1C PersonTitleMsc) (0C Masc OR Fem) ;
     ## Masculine title implies masculine name
 
-# Rule 15: Gender agreement for proper names with feminine titles  
+# Rule 13: Gender agreement for proper names with feminine titles  
 SELECT Fem IF (0C Ant) (-1C PersonTitleFem) (0C Masc OR Fem) ;
     ## Feminine title implies feminine name
 


### PR DESCRIPTION
Simplificarion of rules: positive selection over negative removal.
- Removed REMOVE (n sg gen) rules for plural noun disambiguation
- SELECT rules explicitly choose plural nominative readings
